### PR TITLE
c-hello/xen: Fix config path in run command

### DIFF
--- a/c-hello/run.xen.arm64
+++ b/c-hello/run.xen.arm64
@@ -6,4 +6,4 @@ if test ! -f "out/c-hello_xen-arm64"; then
     exit 1
 fi
 
-sudo xl create -c out/c-hello_xen-arm64
+sudo xl create -c xen.arm64.cfg

--- a/c-hello/run.xen.x86_64
+++ b/c-hello/run.xen.x86_64
@@ -6,4 +6,4 @@ if test ! -f "out/c-hello_xen-x86_64"; then
     exit 1
 fi
 
-sudo xl create -c out/c-hello_xen-x86_64
+sudo xl create -c xen.x86_64.cfg


### PR DESCRIPTION
`xl create` should receive a xen `.cfg` file not the kernel itself.