### PR TITLE
c-http: Fix Customization Typo

### DIFF
--- a/c-http/README.md
+++ b/c-http/README.md
@@ -390,7 +390,7 @@ sudo xl destroy c-http
 
 ## Customize
 
-C Hello is the simplest networking application to be run with Unikraft.
+C HTTP is the simplest networking application to be run with Unikraft.
 This makes it ideal as a minimal testing ground for new features: it builds fast, it only has LWIP as a dependency.
 
 ### Update the Unikraft Core Code


### PR DESCRIPTION
This PR applies changes to the `Customize` chapter of the C HTTP application's README, by updating "C Hello" to "C HTTP".