### PR TITLE
c-http, nginx: Fix typo in the run.xen.x86_64 script

### DIFF
--- a/c-http/run.xen.x86_64
+++ b/c-http/run.xen.x86_64
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if test ! -f "out/c-http_xen-arm64"; then
-    echo "No kernel file out/c-http_xen-arm64." 1>&2
-    echo "Did you run ./build.xen.arm64 ?" 1>&2
+if test ! -f "out/c-http_xen-x86_64"; then
+    echo "No kernel file out/c-http_xen-x86_64." 1>&2
+    echo "Did you run ./build.xen.x86_64 ?" 1>&2
     exit 1
 fi
 

--- a/nginx/run.xen.x86_64
+++ b/nginx/run.xen.x86_64
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if test ! -f "out/nginx_xen-arm64"; then
-    echo "No kernel file out/nginx_xen-arm64." 1>&2
-    echo "Did you run ./build.xen.arm64 ?" 1>&2
+if test ! -f "out/nginx_xen-x86_64"; then
+    echo "No kernel file out/nginx_xen-x86_64." 1>&2
+    echo "Did you run ./build.xen.x86_64 ?" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
This PR makes changes to the C HTTP and Nginx applications, particulartly to their `run.xen.x86_64`, which currently look for arm64 builds instead of x86_64 ones.