### PR TITLE
elfloader-basic: Clone `app-elfloader`

### DIFF
--- a/elfloader-basic/build.fc.x86_64
+++ b/elfloader-basic/build.fc.x86_64
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 test -d "../repos/unikraft" || git clone https://github.com/unikraft/unikraft ../repos/unikraft
+test -d "../repos/apps/elfloader" || git clone https://github.com/unikraft/app-elfloader ../repos/apps/elfloader
 test -d "../repos/libs/libelf" || git clone https://github.com/unikraft/lib-libelf ../repos/libs/libelf
 
 make distclean

--- a/elfloader-basic/build.qemu.x86_64
+++ b/elfloader-basic/build.qemu.x86_64
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 test -d "../repos/unikraft" || git clone https://github.com/unikraft/unikraft ../repos/unikraft
+test -d "../repos/apps/elfloader" || git clone https://github.com/unikraft/app-elfloader ../repos/apps/elfloader
 test -d "../repos/libs/libelf" || git clone https://github.com/unikraft/lib-libelf ../repos/libs/libelf
 
 make distclean


### PR DESCRIPTION
Update build scripts to also clone the `app-elfloader` repository into the `repos/apps` directory if absent.