### PR TITLE
Add Redis app

### DIFF
--- a/redis/.gitignore
+++ b/redis/.gitignore
@@ -1,0 +1,1 @@
+/9pfs-rootfs/

--- a/redis/Config.uk
+++ b/redis/Config.uk
@@ -1,0 +1,32 @@
+# Configure Redis server application for a build that uses initrd to pass the root
+# filesystem and a bridge networking.
+# Enable initrd / CPIO-related core components and configurations.
+# Enable extendeded information for configuring network parameters.
+
+config APPREDIS
+bool "Configure Redis server application with initrd as rootfs"
+default y
+
+    # Select application library (Redis). Use the server main function the
+    # application library. Other libraries, such as Musl or LWIP, are selected
+    # as dependencies of Redis.
+    select LIBREDIS
+    select LIBREDIS_SERVER
+    select LIBREDIS_SERVER_MAIN_FUNCTION
+    select LIBREDIS_LUA
+
+    # Select filesystem core components: vfscore, cpio, ramfs, devfs. For
+    # each select corresponding features. The other core components are
+    # selected as dependencies of Redis.
+    select LIBVFSCORE
+    select LIBVFSCORE_AUTOMOUNT_UP
+    select LIBRAMFS
+    select LIBUKCPIO
+    select LIBDEVFS
+    select LIBDEVFS_AUTOMOUNT
+    select LIBDEVFS_DEVSTDOUT
+
+    # Use extended information (einfo) for configuring network parameters.
+    # This component parses the configuration string in the command line:
+    #    netdev.ip=172.44.0.2/24:172.44.0.1:::
+    select LIBUKNETDEV_EINFO_LIBPARAM

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -1,0 +1,13 @@
+UK_ROOT ?= $(PWD)/../repos/unikraft
+UK_BUILD ?= $(PWD)/out
+UK_APP ?= $(PWD)
+LIBS_BASE = $(PWD)/../repos/libs
+UK_LIBS ?= $(LIBS_BASE)/musl:$(LIBS_BASE)/redis:$(LIBS_BASE)/lwip
+
+.PHONY: all
+
+all:
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD) $(MAKECMDGOALS)

--- a/redis/NOTES.md
+++ b/redis/NOTES.md
@@ -1,0 +1,15 @@
+**2024-09-20**
+
+Hardware randomness support requires a newer version of QEMU (>=8.1) and / or KVM support on newer CPUs.
+If you don't have KVM support or if you using an older version QEMU, add this config to the `defconfig*` files:
+
+```text
+CONFIG_LIBUKRANDOM_SEED_INSECURE=y
+```
+
+And patch the Unikraft core in `../repos/unikraft`:
+
+```console
+wget https://gist.githubusercontent.com/razvand/929d0c9a4d1709d12e2fe1352d98d0a2/raw/de7da30778c3611fbebb6bd557abfeb353e8ea98/0001-lib-ukrandom-Do-not-initialize-hwrandom-for-insecure.patch
+git am 0001-lib-ukrandom-Do-not-initialize-hwrandom-for-insecure.patch
+```

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,0 +1,515 @@
+# Redis on Unikraft
+
+Build and run Redis on Unikraft.
+Follow the instructions below to set up, configure, build and run Redis.
+Make sure you installed the [requirements](../README.md#requirements).
+
+## Quick Setup (aka TLDR)
+
+For a quick setup, run the commands below.
+Note that you still need to install the [requirements](../README.md#requirements).
+
+To build and run the application for `x86_64`, use the commands below:
+
+```console
+test -d ../repos/unikraft || git clone https://github.com/unikraft/unikraft ../repos/unikraft
+test -d ../repos/libs/musl || git clone https://github.com/unikraft/lib-musl ../repos/libs/musl
+test -d ../repos/libs/lwip || git clone https://github.com/unikraft/lib-lwip ../repos/libs/lwip
+test -d ../repos/libs/redis || git clone https://github.com/unikraft/lib-redis ../repos/libs/redis
+make distclean
+> /tmp/defconfig echo 'CONFIG_PLAT_KVM=y
+CONFIG_KVM_VMM_QEMU=y
+CONFIG_ARCH_X86_64=y
+CONFIG_LIBDEVFS=y
+CONFIG_LIBDEVFS_AUTOMOUNT=y
+CONFIG_LIBRAMFS=y
+CONFIG_LIBUK9P=y
+CONFIG_LIBUKCPIO=y
+CONFIG_LIBVFSCORE_AUTOMOUNT_UP=y
+CONFIG_LIBVFSCORE_AUTOMOUNT_FB=y
+CONFIG_LIBUKNETDEV_EINFO_LIBPARAM=y
+CONFIG_LWIP_LOOPIF=y
+CONFIG_LWIP_RAW=y
+CONFIG_LIBREDIS=y
+CONFIG_LIBREDIS_SERVER=y
+CONFIG_LIBREDIS_SERVER_MAIN_FUNCTION=y
+CONFIG_LIBREDIS_LUA=y'
+UK_DEFCONFIG=/tmp/defconfig make defconfig
+make -j $(nproc)
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+test -f initrd.cpio || ../repos/unikraft/support/scripts/mkcpio initrd.cpio ./rootfs/
+sudo qemu-system-x86_64 \
+    -nographic \
+    -m 256 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
+    -kernel out/redis_qemu-x86_64 \
+    -initrd ./initrd.cpio
+```
+
+This will configure, build and run Redis on Unikraft.
+You can see how to test it in the ["Test" section](#test).
+To close the virtual machine, see the instructions in the ["Close QEMU" section](#close-qemu).
+
+To do the same for `AArch64`, run the commands below:
+
+```console
+test -d ../repos/unikraft || git clone https://github.com/unikraft/unikraft ../repos/unikraft
+test -d ../repos/libs/musl || git clone https://github.com/unikraft/lib-musl ../repos/libs/musl
+test -d ../repos/libs/lwip || git clone https://github.com/unikraft/lib-lwip ../repos/libs/lwip
+test -d ../repos/libs/redis || git clone https://github.com/unikraft/lib-redis ../repos/libs/redis
+make distclean
+> /tmp/defconfig echo 'CONFIG_PLAT_KVM=y
+CONFIG_KVM_VMM_QEMU=y
+CONFIG_ARCH_ARM_64=y
+CONFIG_LIBDEVFS=y
+CONFIG_LIBDEVFS_AUTOMOUNT=y
+CONFIG_LIBRAMFS=y
+CONFIG_LIBUK9P=y
+CONFIG_LIBUKCPIO=y
+CONFIG_LIBVFSCORE_AUTOMOUNT_UP=y
+CONFIG_LIBVFSCORE_AUTOMOUNT_FB=y
+CONFIG_LIBUKNETDEV_EINFO_LIBPARAM=y
+CONFIG_LWIP_LOOPIF=y
+CONFIG_LWIP_RAW=y
+CONFIG_LIBREDIS=y
+CONFIG_LIBREDIS_SERVER=y
+CONFIG_LIBREDIS_SERVER_MAIN_FUNCTION=y
+CONFIG_LIBREDIS_LUA=y
+CONFIG_ARM64_ERRATUM_858921=n
+CONFIG_ARM64_ERRATUM_835769=n
+CONFIG_ARM64_ERRATUM_843419=n'
+UK_DEFCONFIG=/tmp/defconfig make defconfig
+make -j $(nproc)
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+test -f initrd.cpio || ../repos/unikraft/support/scripts/mkcpio initrd.cpio ./rootfs/
+sudo qemu-system-aarch64 \
+    -nographic \
+    -m 256 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
+    -kernel out/redis_qemu-arm64 \
+    -initrd ./initrd.cpio
+```
+
+Similar to the `x86_64` build, this will configure, build and run Redis on Unikraft.
+
+Information about every step and about other types of builds is detailed below.
+
+## Set Up
+
+Set up the required repositories.
+Clone them in `../repos/` if not already cloned:
+
+```console
+test -d "../repos/unikraft" || git clone https://github.com/unikraft/unikraft ../repos/unikraft
+test -d "../repos/libs/musl" || git clone https://github.com/unikraft/lib-musl ../repos/libs/musl
+test -d "../repos/libs/redis" || git clone https://github.com/unikraft/lib-redis ../repos/libs/redis
+test -d "../repos/libs/lwip" || git clone https://github.com/unikraft/lib-lwip ../repos/libs/lwip
+```
+
+If you want use a custom variant of a repository (e.g. apply your own patch, make modifications), update it accordingly in the `../repos/` directory.
+
+## Clean
+
+While not strictly required, it is safest to clean the previous build artifacts:
+
+```console
+make distclean
+```
+
+## Configure
+
+To configure the kernel, use:
+
+```console
+make menuconfig
+```
+
+In the console menu interface, choose the target architecture (x86_64 or ARMv8 or ARMv7) and platform (Xen or KVM/QEMU or KVM/Firecracker).
+
+The end result will be the creation of the `.config` configuration file.
+
+## Build
+
+Build the application for the current configuration:
+
+```console
+make -j $(nproc)
+```
+
+This results in the creation of the `out/` directory storing the build artifacts.
+The unikernel application image file is `out/redis_<plat>-<arch>`, where `<plat>` is the platform name (`qemu`, `fc`, `xen`), and `<arch>` is the architecture (`x86_64` or `arm64`).
+
+### Use a Different Compiler
+
+If you want to use a different compiler, such as a Clang or a different GCC version, pass the `CC` variable to `make`.
+
+To build with Clang, use the commands below:
+
+```console
+make properclean
+make CC=clang -j $(nproc)
+```
+
+Note that Clang >= 14 is required to build Unikraft.
+
+To build with another GCC version, use the commands below:
+
+```console
+make properclean
+make CC=gcc-<version> -j $(nproc)
+```
+
+where `<version>` is the GCC version, such as `11`, `12`.
+
+Note that GCC >= 8 is required to build Unikraft.
+
+### Build the Filesystem
+
+The filesystem is to be packed into `initrd.cpio`, an initial ramdisk CPIO file.
+Use the command below for that:
+
+```console
+rm -f initrd.cpio
+../repos/unikraft/support/scripts/mkcpio initrd.cpio ./rootfs/
+```
+
+## Clean Up
+
+Doing a new configuration, or a new build, may require cleaning up the configuration and build artifacts.
+
+In order to remove the build artifacts, use:
+
+```console
+make clean
+```
+
+In order to remove fetched files also, that is the removal of the `out/` directory, use:
+
+```console
+make properclean
+```
+
+In order to remove the generated `.config` file as well, use:
+
+```console
+make distclean
+```
+
+## Run
+
+Run the resulting image using the corresponding platform tool.
+Firecracker requires KVM support.
+Xen requires a system with Xen installed.
+
+A successful run will show a message such as the one below:
+
+```text
+en1: Added
+en1: Interface is up
+Powered by
+o.   .o       _ _               __ _
+Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
+oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
+oOo oOO| | | | |   (| | | (_) |  _) :_
+ OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
+                Calypso 0.17.0~5d38d108
+```
+
+This means that Redis runs on Unikraft and waiting for connections.
+
+### Run on QEMU/x86_64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create bridge interface for QEMU networking.
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+```
+
+Now run the Unikraft image:
+
+```console
+sudo qemu-system-x86_64 \
+    -nographic \
+    -m 256 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
+    -kernel out/redis_qemu-x86_64 \
+    -initrd ./initrd.cpio
+```
+
+You need use `sudo` or the `root` account to run QEMU with bridged networking.
+
+### Run on QEMU/ARM64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create bridge interface for QEMU networking.
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+```
+
+Now run the Unikraft image:
+
+```console
+sudo qemu-system-aarch64 \
+    -nographic \
+    -machine virt \
+    -m 256 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
+    -kernel out/redis_qemu-arm64 \
+    -initrd ./initrd.cpio
+```
+
+You need use `sudo` or the `root` account to run QEMU with bridged networking.
+
+### Run on Firecracker/x86_64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create tap interface for Firecracker networking.
+sudo ip tuntap add dev tap0 mode tap
+sudo ip address add 172.44.0.1/24 dev tap0
+sudo ip link set dev tap0 up
+```
+
+Now run the Unikraft image:
+
+```console
+rm -f firecracker.socket
+sudo firecracker-x86_64 --config-file fc.x86_64.json --api-sock firecracker.socket
+```
+
+The user running the above command must be able to use KVM.
+Typically this means being part of the `kvm` group.
+Otherwise, run the command above as root or prefixed by `sudo`.
+
+### Run on Firecracker/ARM64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create tap interface for Firecracker networking.
+sudo ip tuntap add dev tap0 mode tap
+sudo ip address add 172.44.0.1/24 dev tap0
+sudo ip link set dev tap0 up
+```
+
+Now run the Unikraft image:
+
+```console
+rm -f firecracker.socket
+firecracker-aarch64 --config-file fc.arm64.json --api-sock firecracker.socket
+```
+
+The user running the above command must be able to use KVM.
+Typically this means being part of the `kvm` group.
+Otherwise, run the command above as the `root` account or prefixed by `sudo`.
+
+### Run on Xen/x86_64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create bridge interface for Xen networking.
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+```
+
+Now run the Unikraft image:
+
+```console
+sudo xl create -c xen.x86_64.cfg
+```
+
+You need use `sudo` or the `root` account to run Xen.
+
+### Run on Xen/ARM64
+
+To set up networking, use the commands below:
+
+```console
+# Remove previously created network interfaces. Ignore missing device errors.
+sudo ip link set dev virbr0 down
+sudo ip link del dev virbr0
+sudo ip link set dev tap0 down
+sudo ip link del dev tap0
+# Create bridge interface for Xen networking.
+sudo ip link add dev virbr0 type bridge
+sudo ip address add 172.44.0.1/24 dev virbr0
+sudo ip link set dev virbr0 up
+```
+
+Now run the Unikraft image:
+
+```console
+sudo xl create -c xen.arm64.cfg
+```
+
+You need use `sudo` or the `root` account to run Xen.
+
+## Test
+
+To test if the Unikraft instance of the Redis server works, open another console and use the `redis-cli` command below to query the server:
+
+```console
+redis-cli -h localhost
+```
+
+You can test it using `set/get` commands:
+
+```text
+127.0.0.1:6379> set a 1
+OK
+127.0.0.1:6379> get a
+"1"
+127.0.0.1:6379>
+```
+
+## Close
+
+As a server, Redis will run forever until you close the Unikraft virtual machine that runs it.
+Closing the virtual machine depends on the platform.
+
+### Close QEMU
+
+To close the QEMU virtual machine, use the `Ctrl+a x` keyboard shortcut;
+that is press the `Ctrl` and `a` keys at the same time and then, separately, press the `x` key.
+
+### Close Firecracker
+
+To close the Firecracker virtual machine, open another console and use the command:
+
+```console
+sudo pkill -f firecracker
+```
+
+### Close Xen
+
+To close the Xen virtual machine, open another console and use the command:
+
+```console
+sudo xl destroy redis
+```
+
+## Customize
+
+### Customize the Filesystem Contents
+
+The main way to customize Redis is to update its configuration in the root directory of the filesystem:
+
+```console
+rootfs/
+|-- redis.conf
+```
+
+After updating the filesystem contents, you need to [rebuild the filesystem](#build-the-filesystem) and the [run](#run) the unikernel.
+No rebuild of the unikernel is necessary.
+
+### Use a Different Filesystem Type for QEMU
+
+You can use [`9pfs`](https://github.com/unikraft/unikraft/tree/staging/lib/9pfs) as an alternate filesystem to initrd.
+Note that 9pfs does not work with Firecracker.
+And it requires re-building Xen to add 9pfs support.
+Below find instructions on running Redis on QEMU with 9pfs support.
+
+You need to use these contents for the [`Config.uk`](Config.uk) configuration file:
+
+```text
+config APPREDIS
+bool "Configure Redis application with initrd as rootfs"
+default y
+        select LIBREDIS
+        select LIBREDIS_SERVER
+        select LIBREDIS_SERVER_MAIN_FUNCTION
+        select LIBREDIS_LUA
+        select LIBVFSCORE
+        select LIBVFSCORE_AUTOMOUNT_UP
+        select LIBUK9P
+        select LIB9PFS
+        select LIBDEVFS
+        select LIBDEVFS_AUTOMOUNT
+        select LIBDEVFS_DEVSTDOUT
+        select LIBUKNETDEV_EINFO_LIBPARAM
+```
+
+This means you replace these two lines in [`Config.uk`](Config.uk):
+
+```text
+        select LIBRAMFS
+        select LIBUKCPIO
+```
+
+with these lines:
+
+```text
+        select LIBUK9P
+        select LIB9PFS
+```
+
+Now go through the [configure](#configure) and [build](#build) steps.
+
+Finally, after configuring networking, use the commands below to run Redis on QEMU/x86_64 with 9pfs support:
+
+```console
+# Create a copy of the filesystem to be mounted as 9pfs.
+rm -fr 9pfs-rootfs
+cp -r rootfs 9pfs-rootfs
+sudo qemu-system-x86_64 \
+    -nographic \
+    -m 256 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"fs0:/:9pfs:::\" ] -- /redis.conf" \
+    -kernel out/redis_qemu-x86_64 \
+    -fsdev local,id=myid,path=$(pwd)/9pfs-rootfs/,security_model=none \
+    -device virtio-9p-pci,fsdev=myid,mount_tag=fs0
+```
+
+You would use a similar command for QEMU/ARM64.

--- a/redis/fc.arm64.json
+++ b/redis/fc.arm64.json
@@ -1,0 +1,21 @@
+{
+  "boot-source": {
+    "kernel_image_path": "out/redis_fc-arm64",
+    "boot_args": "redis_fc-arm64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf",
+    "initrd_path": "initrd.cpio"
+  },
+  "drives": [],
+  "machine-config": {
+    "vcpu_count": 1,
+    "mem_size_mib": 256,
+    "smt": false,
+    "track_dirty_pages": false
+  },
+  "network-interfaces": [
+    {
+      "iface_id": "net1",
+      "guest_mac":  "06:00:ac:10:00:02",
+      "host_dev_name": "tap0"
+    }
+  ]
+}

--- a/redis/fc.x86_64.json
+++ b/redis/fc.x86_64.json
@@ -1,0 +1,21 @@
+{
+  "boot-source": {
+    "kernel_image_path": "out/redis_fc-x86_64",
+    "boot_args": "redis_fc-x86_64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf",
+    "initrd_path": "initrd.cpio"
+  },
+  "drives": [],
+  "machine-config": {
+    "vcpu_count": 1,
+    "mem_size_mib": 256,
+    "smt": false,
+    "track_dirty_pages": false
+  },
+  "network-interfaces": [
+    {
+      "iface_id": "net1",
+      "guest_mac":  "06:00:ac:10:00:02",
+      "host_dev_name": "tap0"
+    }
+  ]
+}

--- a/redis/rootfs/redis.conf
+++ b/redis/rootfs/redis.conf
@@ -1,0 +1,6 @@
+bind 0.0.0.0
+port 6379
+tcp-backlog 511
+timeout 0
+tcp-keepalive 300
+protected-mode no

--- a/redis/xen.arm64.cfg
+++ b/redis/xen.arm64.cfg
@@ -1,0 +1,8 @@
+name          = "redis"
+vcpus         = "1"
+kernel        = "./out/redis_xen-arm64"
+ramdisk       = "./initrd.cpio"
+cmdline       = "redis_xen-arm64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf"
+vif           = ['bridge=virbr0']
+memory        = "256"
+type 	      = "pv"

--- a/redis/xen.x86_64.cfg
+++ b/redis/xen.x86_64.cfg
@@ -1,0 +1,8 @@
+name          = "redis"
+vcpus         = "1"
+kernel        = "./out/redis_xen-x86_64"
+ramdisk       = "./initrd.cpio"
+cmdline       = "redis_xen-x86_64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf"
+vif           = ['bridge=virbr0']
+memory        = "256"
+type 	      = "pv"


### PR DESCRIPTION
Add `redis` directory:
- `rootfs/redis.conf`: Redis configuration file
- `Config.uk`: application configuration
- `Makefile`: for building the application
- `Makefile.uk`: empty placeholder file required by build system
- `fc.x86_64.json` / `fc.arm64.json`: Firecracker configuration
- `xen.x86_64.cfg` / `xen.arm64.cfg`: Xen configuration
- `README.md`: instructions
- `.gitignore`: ignore generated files
- `NOTES.md`: notes for QEMU compatibility

Addresses #6 