### PR TITLE
*/Config.uk: Add tty stdio configuration

### DIFF
--- a/cpp-hello/Config.uk
+++ b/cpp-hello/Config.uk
@@ -10,3 +10,6 @@ default y
 	select LIBCXXABI
 	select LIBUNWIND
 	select LIBMUSL
+
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO

--- a/cpp-http/Config.uk
+++ b/cpp-http/Config.uk
@@ -12,6 +12,9 @@ default y
 	select LIBUNWIND
 	select LIBMUSL
 
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO
+
 	# Select LWIP networking stack library
 	select LIBLWIP
 

--- a/elfloader-basic/Config.uk
+++ b/elfloader-basic/Config.uk
@@ -28,3 +28,6 @@ default y
 	select LIBUKCPIO
 	select LIBDEVFS
 	select LIBDEVFS_AUTOMOUNT
+
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO

--- a/elfloader-net/Config.uk
+++ b/elfloader-net/Config.uk
@@ -29,6 +29,9 @@ default y
 	select LIBDEVFS
 	select LIBDEVFS_AUTOMOUNT
 
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO
+
 	# Select LWIP networking stack library.
 	select LIBLWIP
 

--- a/nginx/Config.uk
+++ b/nginx/Config.uk
@@ -24,6 +24,9 @@ default y
 	select LIBDEVFS_AUTOMOUNT
 	select LIBDEVFS_DEVSTDOUT
 
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO
+
 	# Use extended information (einfo) for configuring network parameters.
 	# This component parses the configuration string in the command line:
 	#    netdev.ip=172.44.0.2/24:172.44.0.1:::

--- a/python3-hello/Config.uk
+++ b/python3-hello/Config.uk
@@ -28,3 +28,6 @@ config APPPYTHON3
 	# Add randomness support.
 	select LIBUKRANDOM
 	select LIBUKRANDOM_GETRANDOM
+
+	# Enable standard input/output communication.
+	select LIBPOSIX_TTY_STDIO


### PR DESCRIPTION
[Unikraft PR #1437](https://github.com/unikraft/unikraft/pull/1437) introduced the `LIBPOSIX_TTY_STDIO` config option. This must be enabled in order to use standard descriptors. In particular, this enables applications to print to standard output. If the option is not enabled, nothing is printed. It appears as if the application is doing nothing or hangs (in case of servers).

Native applications that don't use Musl are excepted from this. They still work correctly, even if the configuration is not introduced.

Enable the `LIBPOSIX_TTY_STDIO` option in `Config.uk` files.