### PR TITLE
Add Redis elfloader app

### DIFF
--- a/elfloader-redis/.gitignore
+++ b/elfloader-redis/.gitignore
@@ -1,0 +1,2 @@
+/workdir/
+/rootfs/

--- a/elfloader-redis/Config.uk
+++ b/elfloader-redis/Config.uk
@@ -1,0 +1,40 @@
+# Configure Redis application for a build that uses initrd to pass the root
+# filesystem.
+# Enable initrd / CPIO-related core components and configurations.
+
+config APPELFLOADER_REDIS
+	bool "Configure Redis application with initrd as rootfs"
+	default y
+
+	# Select app-elfloader component.
+	select APPELFLOADER_DEPENDENCIES
+
+	# Configurations options for app-elfloader
+	# (they can't be part of the template atm)
+	select APPELFLOADER_ARCH_PRCTL
+	select APPELFLOADER_BRK
+	select APPELFLOADER_CUSTOMAPPNAME
+	select APPELFLOADER_STACK_NBPAGES
+	select APPELFLOADER_VFSEXEC_EXECBIT
+	select APPELFLOADER_VFSEXEC
+	select APPELFLOADER_HFS
+	select APPELFLOADER_HFS_ETCRESOLVCONF
+	select APPELFLOADER_HFS_ETCHOSTS
+	select APPELFLOADER_HFS_ETCHOSTNAME
+	select APPELFLOADER_HFS_REPLACEEXIST
+
+	# Select filesystem implementation: cpio, ramfs, devfs.
+	select LIBVFSCORE
+	select LIBVFSCORE_AUTOMOUNT_UP
+	select LIBRAMFS
+	select LIBUKCPIO
+	select LIBDEVFS
+	select LIBDEVFS_AUTOMOUNT
+
+	# Select LWIP networking stack library.
+	select LIBLWIP
+
+	# Use extended information (einfo) for configuring network parameters.
+	# This component parses the configuration string in the command line:
+	#    netdev.ip=172.44.0.2/24:172.44.0.1:::
+	select LIBUKNETDEV_EINFO_LIBPARAM

--- a/elfloader-redis/Dockerfile
+++ b/elfloader-redis/Dockerfile
@@ -1,0 +1,16 @@
+FROM redis:7.2.2-bookworm AS build
+
+FROM scratch
+
+# Redis binaries, modules, configuration, log and runtime files
+COPY --from=build /usr/local/bin/redis-server /usr/bin/redis-server
+
+# Libraries
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Custom configuration files, including using a single process for Redis
+COPY ./redis.conf /etc/redis/redis.conf

--- a/elfloader-redis/Makefile
+++ b/elfloader-redis/Makefile
@@ -1,0 +1,13 @@
+UK_ROOT ?= $(PWD)/workdir/unikraft
+UK_BUILD ?= $(PWD)/workdir/build
+UK_APP ?= $(PWD)/workdir/apps/elfloader
+LIBS_BASE = $(PWD)/workdir/libs
+UK_LIBS ?= $(LIBS_BASE)/libelf:$(LIBS_BASE)/lwip
+
+.PHONY: all
+
+all:
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD) $(MAKECMDGOALS)

--- a/elfloader-redis/fc.x86_64.json
+++ b/elfloader-redis/fc.x86_64.json
@@ -1,0 +1,21 @@
+{
+  "boot-source": {
+    "kernel_image_path": "workdir/build/elfloader_fc-x86_64",
+    "boot_args": "elfloader_fc-x86_64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /usr/bin/redis-server /etc/redis/redis.conf",
+    "initrd_path": "initrd.cpio"
+  },
+  "drives": [],
+  "machine-config": {
+    "vcpu_count": 1,
+    "mem_size_mib": 512,
+    "smt": false,
+    "track_dirty_pages": false
+  },
+  "network-interfaces": [
+    {
+      "iface_id": "net1",
+      "guest_mac":  "06:00:ac:10:00:02",
+      "host_dev_name": "tap0"
+    }
+  ]
+}

--- a/elfloader-redis/redis.conf
+++ b/elfloader-redis/redis.conf
@@ -1,0 +1,6 @@
+bind 0.0.0.0
+port 6379
+tcp-backlog 511
+daemonize no
+timeout 0
+tcp-keepalive 300

--- a/elfloader-redis/setup.sh
+++ b/elfloader-redis/setup.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+check_exists_and_create_symlink()
+{
+    path="$1"
+
+    if ! test -d workdir/"$path"; then
+        if ! test -d ../repos/"$path"; then
+            echo "No directory ../repos/$path. Run the top-level setup.sh script first." 1>&2
+            exit 1
+        fi
+        depth=$(echo "$path" | awk -F / '{ print NF }')
+        if test "$depth" -eq 1; then
+            ln -sfn ../../repos/"$path" workdir/"$path"
+        elif test "$depth" -eq 2; then
+            ln -sfn ../../../repos/"$path" workdir/"$path"
+        else
+            echo "Unknown depth of path $path." 1>&2
+            exit 1
+        fi
+    fi
+}
+
+if ! test -d workdir; then
+    mkdir workdir
+fi
+
+if ! test -d workdir/libs; then
+    mkdir workdir/libs
+fi
+
+if ! test -d workdir/apps; then
+    mkdir workdir/apps
+fi
+
+check_exists_and_create_symlink "unikraft"
+check_exists_and_create_symlink "libs/lwip"
+check_exists_and_create_symlink "libs/libelf"
+check_exists_and_create_symlink "apps/elfloader"


### PR DESCRIPTION
Introduce Redis app (based on elfloader-net)

Add the `redis-elfloader/` directory:

- `Config.uk`: application configuration
- `Makefile`: for building the application
- `fc.x86_64.json`: Firecracker configuration
- `Dockerfile`: for building the root filesystem
- `redis.conf`: Redis server configuration

Note: Instructions for running this application have not been included in this PR, as the structure of apps based on elfloader is subject to change.