### PR TITLE
[WIP] app/c-fs: Changed Config.uk to support 9pfs

### DIFF
--- a/c-fs/Config.uk
+++ b/c-fs/Config.uk
@@ -9,5 +9,5 @@ default y
 	# Select filesystem core components: vfscore, cpio, ramfs.
 	select LIBVFSCORE
 	select LIBVFSCORE_AUTOMOUNT_UP
-	select LIBRAMFS
-	select LIBUKCPIO
+        select LIBUK9P
+        select LIB9PFS


### PR DESCRIPTION
This draft PR adds initial 9pfs filesystem support for the `c-fs` application.

Changes:
- Updated Config.uk to replace initrd/RAMFS with 9pfs support

Still working on:
- Added initial usage instructions for 9pfs in README.md
- Testing

Signed-off-by: Mario-Alin GHEORGHISOR <mariogheorghisor189@gmail.com>