### PR TITLE
Increase start timeout for `python3-hello`.

### DIFF
--- a/python3-hello/scripts/test/common.sh
+++ b/python3-hello/scripts/test/common.sh
@@ -38,7 +38,7 @@ start_instance()
 start_instance_timeout()
 {
     # Start instance.
-    setsid --fork timeout -k 2 15 "$start_command" 1>&2 &
+    setsid --fork timeout -k 2 30 "$start_command" 1>&2 &
     if test $? -ne 0; then
         echo "Cannot start instance" 1>&2
         echo "FAILED"


### PR DESCRIPTION
GitHub Actions need more time for apps that use Docker. Increase timeout from 15 to 30 seconds.

`python3-hello`: increase start timeout.