### PR TITLE
nginx: Fix default configuration for better performance

### DIFF
--- a/nginx/rootfs/nginx/conf/nginx.conf
+++ b/nginx/rootfs/nginx/conf/nginx.conf
@@ -2,10 +2,10 @@ worker_processes  1;
 daemon off;
 master_process off;
 
-error_log logs/error.log debug;
+error_log logs/error.log error;
 
 events {
-  worker_connections 32;
+  worker_connections 128;
 }
 
 http {


### PR DESCRIPTION
The default nginx.conf in the nginx catalog-core app has two issues:

`error_log logs/error.log debug` — debug-level logging generates excessive I/O under load. Changed to error level, which still logs actual errors but doesn't flood the output during normal operation.
`worker_connections 32` — this is nearly exhausted by a typical 30-connection benchmark. Increased to 128 to provide reasonable headroom.
Related to #77. The deeper cause of the alternating throughput issue (`TIME_WAIT accumulation in lwIP`) is addressed in a separate PR to [lib-lwip](https://github.com/unikraft/lib-lwip/pull/74).
