### PR TITLE
README.md: Update GCC version requirement to 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ In order to set up, configure, build and run applications on Unikraft using firs
 * `g++-aarch64-linux-gnu`
 * `bsdcpio`
 
-GCC >= 8 is required to build Unikraft.
+The required GCC for building unikraft depends on the target architecture:
+* **ARM:** GCC >= 8
+* **x86_64:** GCC >= 11
 
 On Ubuntu/Debian or other `apt`-based distributions, use the following command to install the requirements:
 


### PR DESCRIPTION
Building Unikraft on x86_64 now requires GCC >= 11 due to the use of 
`__attribute__((target("general-regs-only")))` introduced in unikraft/unikraft#1688. 

Attempts with GCC 10.x fail as reported in unikraft/unikraft#1728.

Ref: unikraft/unikraft#1728