### PR TITLE
scripts/run: Redirect QEMU stdin to /dev/null to prevent SIGTTIN

### DIFF
--- a/bincompat-c-hello/.scripts/run/qemu.x86_64
+++ b/bincompat-c-hello/.scripts/run/qemu.x86_64
@@ -19,4 +19,5 @@ qemu-system-x86_64 \
     -cpu max \
     -append "elfloader_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /hello-c" \
     -kernel "$base_kernel" \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/bincompat-java-hello/.scripts/run/qemu.x86_64
+++ b/bincompat-java-hello/.scripts/run/qemu.x86_64
@@ -23,4 +23,5 @@ qemu-system-x86_64 \
     -cpu max \
     -append "java-hello_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /usr/lib/jvm/java-17-openjdk-amd64/bin/java /usr/src/hello" \
     -kernel workdir/build/java-hello_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/c-fs/.scripts/run/qemu.arm64
+++ b/c-fs/.scripts/run/qemu.arm64
@@ -17,4 +17,5 @@ qemu-system-aarch64 \
     -cpu max \
     -kernel workdir/build/c-fs_qemu-arm64 \
     -append "c-fs_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /hello.txt" \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/c-fs/.scripts/run/qemu.x86_64
+++ b/c-fs/.scripts/run/qemu.x86_64
@@ -16,4 +16,5 @@ qemu-system-x86_64 \
     -cpu max \
     -kernel workdir/build/c-fs_qemu-x86_64 \
     -append "c-fs_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /hello.txt" \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/c-hello/.scripts/run/qemu.arm64
+++ b/c-hello/.scripts/run/qemu.arm64
@@ -11,4 +11,5 @@ qemu-system-aarch64 \
     -machine virt \
     -m 8 \
     -cpu max \
-    -kernel workdir/build/c-hello_qemu-arm64
+    -kernel workdir/build/c-hello_qemu-arm64 \
+    < /dev/null

--- a/c-hello/.scripts/run/qemu.x86_64
+++ b/c-hello/.scripts/run/qemu.x86_64
@@ -10,4 +10,5 @@ qemu-system-x86_64 \
     -nographic \
     -m 8 \
     -cpu max \
-    -kernel workdir/build/c-hello_qemu-x86_64
+    -kernel workdir/build/c-hello_qemu-x86_64 \
+    < /dev/null

--- a/c-http/.scripts/run/qemu.arm64
+++ b/c-http/.scripts/run/qemu.arm64
@@ -26,4 +26,5 @@ sudo qemu-system-aarch64 \
     -cpu max \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "c-http netdev.ip=172.44.0.2/24:172.44.0.1::: -- " \
-    -kernel workdir/build/c-http_qemu-arm64
+    -kernel workdir/build/c-http_qemu-arm64 \
+    < /dev/null

--- a/c-http/.scripts/run/qemu.x86_64
+++ b/c-http/.scripts/run/qemu.x86_64
@@ -25,4 +25,5 @@ sudo qemu-system-x86_64 \
     -cpu max \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "c-http netdev.ip=172.44.0.2/24:172.44.0.1::: -- " \
-    -kernel workdir/build/c-http_qemu-x86_64
+    -kernel workdir/build/c-http_qemu-x86_64 \
+    < /dev/null

--- a/click/.scripts/run/qemu.arm64
+++ b/click/.scripts/run/qemu.arm64
@@ -19,4 +19,5 @@ sudo qemu-system-aarch64 \
     -kernel workdir/build/click_qemu-arm64 \
     -initrd helloworld.click \
     -machine virt -cpu max \
-    -nographic
+    -nographic \
+    < /dev/null

--- a/click/.scripts/run/qemu.x86_64
+++ b/click/.scripts/run/qemu.x86_64
@@ -17,4 +17,5 @@ sudo qemu-system-x86_64 \
     -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 --" \
     -kernel workdir/build/click_qemu-x86_64 \
     -initrd helloworld.click \
-    -nographic
+    -nographic \
+    < /dev/null

--- a/cpp-hello/.scripts/run/qemu.arm64
+++ b/cpp-hello/.scripts/run/qemu.arm64
@@ -11,4 +11,5 @@ qemu-system-aarch64 \
     -machine virt \
     -m 8 \
     -cpu max \
-    -kernel workdir/build/cpp-hello_qemu-arm64
+    -kernel workdir/build/cpp-hello_qemu-arm64 \
+    < /dev/null

--- a/cpp-hello/.scripts/run/qemu.x86_64
+++ b/cpp-hello/.scripts/run/qemu.x86_64
@@ -10,4 +10,5 @@ qemu-system-x86_64 \
     -nographic \
     -m 8 \
     -cpu max \
-    -kernel workdir/build/cpp-hello_qemu-x86_64
+    -kernel workdir/build/cpp-hello_qemu-x86_64 \
+    < /dev/null

--- a/cpp-http/.scripts/run/qemu.arm64
+++ b/cpp-http/.scripts/run/qemu.arm64
@@ -26,4 +26,5 @@ sudo qemu-system-aarch64 \
     -cpu max \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "cpp-http netdev.ip=172.44.0.2/24:172.44.0.1::: -- " \
-    -kernel workdir/build/cpp-http_qemu-arm64
+    -kernel workdir/build/cpp-http_qemu-arm64 \
+    < /dev/null

--- a/cpp-http/.scripts/run/qemu.x86_64
+++ b/cpp-http/.scripts/run/qemu.x86_64
@@ -25,4 +25,5 @@ sudo qemu-system-x86_64 \
     -cpu max \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "cpp-http netdev.ip=172.44.0.2/24:172.44.0.1::: -- " \
-    -kernel workdir/build/cpp-http_qemu-x86_64
+    -kernel workdir/build/cpp-http_qemu-x86_64 \
+    < /dev/null

--- a/elfloader-basic/.scripts/run/qemu.x86_64
+++ b/elfloader-basic/.scripts/run/qemu.x86_64
@@ -19,4 +19,5 @@ qemu-system-x86_64 \
     -cpu max \
     -append "elfloader_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /hello-c" \
     -kernel workdir/build/elfloader_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/elfloader-net/.scripts/run/qemu.x86_64
+++ b/elfloader-net/.scripts/run/qemu.x86_64
@@ -33,4 +33,5 @@ sudo qemu-system-x86_64 \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "elfloader_qemu-x86_64 netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /c-server" \
     -kernel workdir/build/elfloader_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/nginx/.scripts/run/qemu.arm64
+++ b/nginx/.scripts/run/qemu.arm64
@@ -31,4 +31,5 @@ sudo qemu-system-aarch64 \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "nginx netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- -c /nginx/conf/nginx.conf" \
     -kernel workdir/build/nginx_qemu-arm64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/nginx/.scripts/run/qemu.x86_64
+++ b/nginx/.scripts/run/qemu.x86_64
@@ -30,4 +30,5 @@ sudo qemu-system-x86_64 \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "nginx netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- -c /nginx/conf/nginx.conf" \
     -kernel workdir/build/nginx_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/python3-hello/.scripts/run/qemu.arm64
+++ b/python3-hello/.scripts/run/qemu.arm64
@@ -21,4 +21,5 @@ qemu-system-aarch64 \
     -cpu max \
     -append "python3-hello_qemu-arm64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] env.vars=[ PYTHONPATH=\"/usr/local/lib/python3.10:/usr/local/lib/python3.10/site-packages\" ] -- /app/hello.py" \
     -kernel workdir/build/python3-hello_qemu-arm64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/python3-hello/.scripts/run/qemu.x86_64
+++ b/python3-hello/.scripts/run/qemu.x86_64
@@ -20,4 +20,5 @@ qemu-system-x86_64 \
     -cpu max \
     -append "python3-hello_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] env.vars=[ PYTHONPATH=\"/usr/local/lib/python3.10:/usr/local/lib/python3.10/site-packages\" ] -- /app/hello.py" \
     -kernel workdir/build/python3-hello_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/redis/.scripts/run/qemu.arm64
+++ b/redis/.scripts/run/qemu.arm64
@@ -31,4 +31,5 @@ sudo qemu-system-aarch64 \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
     -kernel workdir/build/redis_qemu-arm64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/redis/.scripts/run/qemu.x86_64
+++ b/redis/.scripts/run/qemu.x86_64
@@ -30,4 +30,5 @@ sudo qemu-system-x86_64 \
     -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
     -append "redis netdev.ip=172.44.0.2/24:172.44.0.1::: vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- /redis.conf" \
     -kernel workdir/build/redis_qemu-x86_64 \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/sqlite/.scripts/run/qemu.arm64
+++ b/sqlite/.scripts/run/qemu.arm64
@@ -16,4 +16,5 @@ qemu-system-aarch64 \
     -cpu max \
     -kernel workdir/build/sqlite_qemu-arm64 \
     -append "sqlite_qemu-arm64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] env.vars=[ \"HOME=/root\" ] -- /chinook.db 'SELECT * FROM Album LIMIT 10'" \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/sqlite/.scripts/run/qemu.x86_64
+++ b/sqlite/.scripts/run/qemu.x86_64
@@ -14,4 +14,5 @@ qemu-system-x86_64 \
     -nographic \
     -kernel workdir/build/sqlite_qemu-x86_64 \
     -append "sqlite_qemu-x86_64 vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] env.vars=[ \"HOME=/root\" ] -- /chinook.db 'SELECT * FROM Album LIMIT 10'" \
-    -initrd ./initrd.cpio
+    -initrd ./initrd.cpio \
+    < /dev/null

--- a/wamr/.scripts/run/qemu.x86_64
+++ b/wamr/.scripts/run/qemu.x86_64
@@ -30,5 +30,5 @@ sudo qemu-system-x86_64 \
     -cpu max \
     -append "vfs.fstab=[ \"initrd0:/:extract::ramfs=1:\" ] -- $cmd" \
     -kernel "$kernel" \
-    -initrd "$PWD"/rootfs.cpio
-
+    -initrd "$PWD"/rootfs.cpio \
+    < /dev/null


### PR DESCRIPTION
Bug that is fixed : whenever the testing scripts boots up the QEMU Virtual Machine, it is put in background. Because of that, it is not allowed to read from the terminal, so the kernel sends SIGTTIN and suspends it, making the test fail automatically.

Fix : Just redirect stdin to /dev/null so that QEMU gets EOF instead. The fix was tested with wrapper.sh on nginx.